### PR TITLE
fix: relay resilience — auto-reconnect, catch publish errors, improve observability

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -247,13 +247,13 @@ export const nip17Plugin: ChannelPlugin<ResolvedNip17Account> = {
           ctx.log?.error?.(`[${account.accountId}] NIP-17 error (${context}): ${error.message}`);
         },
         onConnect: (relay) => {
-          ctx.log?.debug?.(`[${account.accountId}] Connected to relay: ${relay}`);
+          ctx.log?.info?.(`[${account.accountId}] Connected to relay: ${relay}`);
         },
         onDisconnect: (relay) => {
-          ctx.log?.debug?.(`[${account.accountId}] Disconnected from relay: ${relay}`);
+          ctx.log?.warn?.(`[${account.accountId}] Disconnected from relay: ${relay}`);
         },
         onEose: (relays) => {
-          ctx.log?.debug?.(`[${account.accountId}] EOSE from: ${relays}`);
+          ctx.log?.info?.(`[${account.accountId}] EOSE from: ${relays}`);
         },
       });
 

--- a/src/nip17-bus.ts
+++ b/src/nip17-bus.ts
@@ -216,8 +216,6 @@ export async function startNip17Bus(options: Nip17BusOptions): Promise<Nip17BusH
       // Skip rumors we've already seen — only process newer than last known rumor timestamp
       if (lastRumorAt > 0 && rumor.created_at <= lastRumorAt) return;
 
-      // Already marked in globalDedup above
-
       const senderPubkey = rumor.pubkey;
       const text = rumor.content;
 
@@ -238,20 +236,40 @@ export async function startNip17Bus(options: Nip17BusOptions): Promise<Nip17BusH
 
   // Subscribe to kind 1059 (gift wraps) addressed to us
   // Use since set to 2 days ago to catch NIP-59 randomized timestamps
-  const sub = pool.subscribeMany(
-    relays,
-    { kinds: [1059], "#p": [pk], since } as any,
-    {
-      onevent: handleEvent,
-      oneose: () => {
-        onEose?.(relays.join(", "));
+  let closed = false;
+  let reconnectAttempts = 0;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function subscribe() {
+    const subSince = Math.max(0, Math.floor(Date.now() / 1000) - STARTUP_LOOKBACK_SEC);
+    return pool.subscribeMany(
+      relays,
+      { kinds: [1059], "#p": [pk], since: subSince } as any,
+      {
+        onevent: handleEvent,
+        oneose: () => {
+          reconnectAttempts = 0; // reset backoff on successful EOSE
+          onEose?.(relays.join(", "));
+        },
+        onclose: (reason) => {
+          options.onDisconnect?.(relays.join(", "));
+          onError?.(new Error(`Subscription closed: ${reason}`), "subscription");
+          if (!closed) {
+            const delay = Math.min(5000 * Math.pow(2, reconnectAttempts), 5 * 60 * 1000);
+            reconnectAttempts++;
+            onError?.(new Error(`Reconnecting in ${delay / 1000}s (attempt ${reconnectAttempts})`), "reconnect");
+            reconnectTimer = setTimeout(() => {
+              if (!closed) {
+                activeSub = subscribe();
+              }
+            }, delay);
+          }
+        },
       },
-      onclose: (reason) => {
-        options.onDisconnect?.(relays.join(", "));
-        onError?.(new Error(`Subscription closed: ${reason}`), "subscription");
-      },
-    },
-  );
+    );
+  }
+
+  let activeSub = subscribe();
 
   const sendDm = async (toPubkey: string, text: string): Promise<void> => {
     await sendNip17Dm(pool, sk, toPubkey, text, relays, onError);
@@ -259,7 +277,9 @@ export async function startNip17Bus(options: Nip17BusOptions): Promise<Nip17BusH
 
   return {
     close: () => {
-      sub.close();
+      closed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      activeSub.close();
       persistStateNow();
     },
     publicKey: pk,
@@ -302,7 +322,11 @@ async function sendNip17Dm(
   const publishPromises: Promise<any>[] = [];
   for (const wrap of [wrapForRecipient, wrapForSelf]) {
     for (const relay of relays) {
-      publishPromises.push(pool.publish([relay], wrap as any));
+      publishPromises.push(
+        pool.publish([relay], wrap as any).catch((err: unknown) => {
+          onError?.(err instanceof Error ? err : new Error(String(err)), `publish to ${relay}`);
+        })
+      );
     }
   }
 


### PR DESCRIPTION
## Problem

Two issues causing the NIP-17 plugin to silently stop receiving messages or crash the gateway:

1. **No reconnect on subscription close** — when relay websockets drop (idle timeout, restart, network blip), the subscription dies permanently. Messages stop arriving until the gateway is manually restarted.

2. **Unhandled publish errors crash the gateway** — relay rate-limit responses (e.g. "you are noting too much") from `pool.publish()` become unhandled promise rejections that kill the entire Node process. This was causing random gateway restarts in production.

## Fix

### 1. Auto-reconnect with exponential backoff (`nip17-bus.ts`)
When `onclose` fires, automatically re-subscribe with exponential backoff (5s → 10s → 20s → ... max 5min). Backoff resets on successful EOSE. Clean shutdown via `closed` flag prevents reconnect attempts after intentional close.

### 2. Catch `pool.publish()` errors (`nip17-bus.ts`)
Each `pool.publish()` call is now wrapped with `.catch()` so relay errors are logged via `onError` instead of becoming unhandled promise rejections that crash the process.

### 3. Bump logging levels (`channel.ts`)
Connect/disconnect/EOSE callbacks promoted from `debug` to `info`/`warn` for production observability. Previously, relay disconnections were invisible in logs, making it impossible to diagnose connection issues.

## Testing

Running in production. Previously required daily gateway restarts due to:
- Silent subscription death overnight (relay idle timeouts)
- Gateway crashes from relay rate-limit errors on publish

Both issues are now resolved. Relay reconnections happen automatically and are visible in logs.

## Files Changed

- `src/nip17-bus.ts` — fixes 1, 2
- `src/channel.ts` — fix 3