### PR TITLE
fix: enable SimplePool ping + reconnect to stop silent sub deaths

### DIFF
--- a/src/nip17-bus.ts
+++ b/src/nip17-bus.ts
@@ -159,12 +159,21 @@ export async function startNip17Bus(options: Nip17BusOptions): Promise<Nip17BusH
   const normalizeRelayUrl = (url: string) => url.replace(/\/+$/, "").toLowerCase();
   const trustedRelays = new Set(relays.map(normalizeRelayUrl));
 
+  // enablePing: keeps WebSockets alive with 29s heartbeats and surfaces silent
+  //   TCP deaths as clean onclose events so the reconnect path below fires.
+  //   Without this, idle relays (nos.lol, damus, primal) silently drop the
+  //   socket after a few minutes and the bot stops receiving DMs without ever
+  //   knowing anything went wrong — no onclose, no reconnect, just deafness.
+  // enableReconnect: lets the underlying AbstractRelay resubscribe by itself
+  //   after transient drops so re-auth + re-REQ happen automatically.
   const pool = new SimplePool({
+    enablePing: true,
+    enableReconnect: true,
     automaticallyAuth: (url: string) => {
       if (!trustedRelays.has(normalizeRelayUrl(url))) return undefined;
       return (authEvent: any) => finalizeEvent(authEvent, sk);
     },
-  });
+  } as any);
   const accountId = options.accountId ?? pk.slice(0, 16);
   const gatewayStartedAt = Math.floor(Date.now() / 1000);
 
@@ -332,6 +341,10 @@ export async function startNip17Bus(options: Nip17BusOptions): Promise<Nip17BusH
   let closed = false;
   let reconnectAttempts = 0;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  // Safety-net: even with pings enabled, force a full close+resubscribe every
+  // REFRESH_INTERVAL_MS so nothing can silently drift for more than this window.
+  let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+  const REFRESH_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 
   // NIP-42 auth signer for subscription-level auth-required retries
   const authSigner = (authEvent: any) => finalizeEvent(authEvent, sk);
@@ -368,6 +381,27 @@ export async function startNip17Bus(options: Nip17BusOptions): Promise<Nip17BusH
 
   let activeSub = subscribe();
 
+  function scheduleRefresh(): void {
+    if (closed) return;
+    refreshTimer = setTimeout(() => {
+      if (closed) return;
+      try {
+        onError?.(new Error(`Periodic subscription refresh (every ${REFRESH_INTERVAL_MS / 60000}min)`), "refresh");
+        // Closing the old sub triggers onclose → reconnect path, which will
+        // rebuild activeSub via subscribe(). We avoid calling subscribe()
+        // directly here to keep a single source of truth for sub creation.
+        activeSub.close();
+      } catch (err) {
+        onError?.(err as Error, "refresh-close");
+      } finally {
+        scheduleRefresh();
+      }
+    }, REFRESH_INTERVAL_MS);
+    // Don't let the refresh timer keep the process alive on its own.
+    if (typeof (refreshTimer as any)?.unref === "function") (refreshTimer as any).unref();
+  }
+  scheduleRefresh();
+
   const sendDm = async (toPubkey: string, text: string): Promise<void> => {
     await sendNip17Dm(pool, sk, toPubkey, text, relays, trustedRelays, onError);
   };
@@ -376,6 +410,7 @@ export async function startNip17Bus(options: Nip17BusOptions): Promise<Nip17BusH
     close: () => {
       closed = true;
       if (reconnectTimer) clearTimeout(reconnectTimer);
+      if (refreshTimer) clearTimeout(refreshTimer);
       activeSub.close();
       persistStateNow();
     },


### PR DESCRIPTION
Fixes #11.

## Problem

Idle WebSocket connections to relays like `nos.lol`, `relay.damus.io`, `relay.primal.net` are silently closed (no FIN, no RST visible to the client) after a few minutes. Because `nostr-tools` `SimplePool` is constructed with the defaults (`enablePing: false`, `enableReconnect: false`), the bot never notices the sockets are dead: no `close` event fires, so the plugin's existing reconnect path in `onclose` never runs, and inbound NIP-17 DMs silently stop arriving while the gateway keeps reporting itself healthy.

Observed on `kcmq.dergigi.com` (8 accounts × 4 relays): after running ~36h, `ss -tn` inside the container showed **1** established TCP connection out of the expected **~32**. A `docker restart` restored DMs until the next silent death a few hours later. See #11 for the full investigation.

## Fix

Two `nostr-tools` features solve this directly; they just need to be opted into on the pool:

```diff
+  // enablePing: keeps WebSockets alive with 29s heartbeats and surfaces silent
+  //   TCP deaths as clean onclose events so the reconnect path below fires.
+  // enableReconnect: lets the underlying AbstractRelay resubscribe by itself
+  //   after transient drops so re-auth + re-REQ happen automatically.
   const pool = new SimplePool({
+    enablePing: true,
+    enableReconnect: true,
     automaticallyAuth: (url: string) => {
       if (!trustedRelays.has(normalizeRelayUrl(url))) return undefined;
       return (authEvent: any) => finalizeEvent(authEvent, sk);
     },
-  });
+  } as any);
```

As belt-and-suspenders I also added a 30-minute `refreshTimer` that force-closes the active sub (which then rebuilds via the existing `onclose` → reconnect path), so nothing can silently drift for more than that window even if the two flags above ever regress.

## Verification

Running this patch on `kcmq.dergigi.com` for the last hour:

- Established TCP connections to port 443 inside the container: **34** (was **1** before the fix). Matches 8 accounts × 4 relays + discovery pool.
- All 8 accounts hit `EOSE` cleanly on startup with **no** `Subscription closed` / `Disconnected from relay` errors.
- End-to-end DM round-trip from an external npub → Sven (`default` account) → reply succeeds within ~10s of publish. Reply went out to 6/8 relays (the 2 failures were expected WoT blocks, unrelated).

## Notes

- The `as any` cast is needed because `@types/nostr-tools` ^2.23.1 doesn't currently expose `enablePing` / `enableReconnect` on the `SimplePool` constructor options, even though the runtime supports them. Happy to drop the cast once types catch up (or add them via module augmentation if you prefer).
- Orthogonal to #10 — that one is a loud crash during AUTH, this one is a silent deafness after idle. Both bite in practice; this PR only addresses the silent-deafness class.