### PR TITLE
feat: add NIP-25 reaction feedback for inbound DMs

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,5 +1,5 @@
 import { type ChannelPlugin, DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/core";
-import { createReplyPrefixOptions } from "openclaw/plugin-sdk/channel-runtime";
+import { createReplyPrefixOptions, createTypingCallbacks } from "openclaw/plugin-sdk/channel-runtime";
 import { buildChannelConfigSchema, collectStatusIssuesFromLastError, createDefaultChannelRuntimeState, formatPairingApproveHint } from "openclaw/plugin-sdk/nostr";
 import { Nip17ConfigSchema } from "./config-schema.js";
 import { normalizePubkey, startNip17Bus, type Nip17BusHandle } from "./nip17-bus.js";
@@ -15,6 +15,12 @@ import * as path from "path";
 import * as os from "os";
 
 const activeBuses = new Map<string, Nip17BusHandle>();
+
+// Visible feedback while a reply is being computed. Sent as kind:7 reactions
+// (NIP-25, gift-wrapped per NIP-17) targeting the inbound rumor. Single pass —
+// no looping; once exhausted, the row stops growing.
+const THINKING_EMOJIS = ["💭", "🧠", "🤔", "💡", "⚙️", "🔍", "📚", "⏳"];
+const THINKING_INTERVAL_MS = 5000;
 
 async function ensureActiveBus(accountId: string): Promise<Nip17BusHandle> {
   const existing = activeBuses.get(accountId);
@@ -203,10 +209,16 @@ export const nip17Plugin: ChannelPlugin<ResolvedNip17Account> = {
         accountId: account.accountId,
         privateKey: account.privateKey,
         relays: account.relays,
-        onMessage: async (senderPubkey, text, replyFn, media) => {
+        onMessage: async (senderPubkey, text, replyFn, media, reactFn) => {
           const hasMedia = media && media.length > 0;
           const mediaDesc = hasMedia ? ` with ${media.length} media attachment(s)` : "";
           ctx.log?.info(`[${account.accountId}] NIP-17 DM from ${senderPubkey}${mediaDesc}: ${text.slice(0, 50)}...`);
+
+          // Receipt: fire-and-forget so the sender sees a reaction even if the
+          // reply pipeline guards short-circuit (pairing/policy/no-binding).
+          // Intentionally outside the typing cycle — this is a "received"
+          // signal, not a "thinking" signal.
+          void reactFn("🤙").catch(() => { /* logged via onError in bus */ });
 
           const cfg = runtime.config.loadConfig();
 
@@ -311,6 +323,23 @@ export const nip17Plugin: ChannelPlugin<ResolvedNip17Account> = {
             accountId: account.accountId,
           });
 
+          // Thinking cycle: walk THINKING_EMOJIS once, no looping. The
+          // dispatcher invokes start() on reply-start, then re-invokes it
+          // every keepaliveIntervalMs until first deliver, NO_REPLY, or abort
+          // — at which point onCleanup fires. maxDurationMs is a safety TTL.
+          let cycleIndex = 0;
+          const typing = createTypingCallbacks({
+            start: async () => {
+              if (cycleIndex >= THINKING_EMOJIS.length) return;
+              const emoji = THINKING_EMOJIS[cycleIndex++];
+              await reactFn(emoji);
+            },
+            stop: async () => { /* no completion emoji — reply DM is the signal */ },
+            onStartError: () => { /* swallow; reactFn already reports via onError */ },
+            keepaliveIntervalMs: THINKING_INTERVAL_MS,
+            maxDurationMs: THINKING_EMOJIS.length * THINKING_INTERVAL_MS,
+          });
+
           // Dispatch reply through the full pipeline
           await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
             ctx: ctxPayload,
@@ -318,6 +347,8 @@ export const nip17Plugin: ChannelPlugin<ResolvedNip17Account> = {
             dispatcherOptions: {
               ...prefixOptions,
               onModelSelected,
+              onReplyStart: typing.onReplyStart,
+              onTypingCleanup: typing.onCleanup,
               deliver: async (payload: { text?: string; mediaPath?: string }) => {
                 const responseText = payload.text ?? "";
                 if (responseText.trim()) {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -336,17 +336,16 @@ export const nip17Plugin: ChannelPlugin<ResolvedNip17Account> = {
             accountId: account.accountId,
           });
 
-          // Dispatch reply through the full pipeline
+          // Dispatch reply through the full pipeline.
+          // dispatcherOptions: delivery + typing-side hooks (onReplyStart lives here).
+          // replyOptions: agent-lifecycle hooks (tool/plan/compaction) and onModelSelected,
+          // which the prefix template needs to interpolate {{model}} post-fallback.
           await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
             ctx: ctxPayload,
             cfg,
             dispatcherOptions: {
               ...prefixOptions,
-              onModelSelected,
               onReplyStart: () => fireReaction(pickThinking()),
-              onToolStart: () => fireReaction(EVENT_EMOJI.toolStart),
-              onPlanUpdate: () => fireReaction(EVENT_EMOJI.planUpdate),
-              onCompactionStart: () => fireReaction(EVENT_EMOJI.compactionStart),
               deliver: async (payload: { text?: string; mediaPath?: string }) => {
                 const responseText = payload.text ?? "";
                 if (responseText.trim()) {
@@ -357,6 +356,12 @@ export const nip17Plugin: ChannelPlugin<ResolvedNip17Account> = {
               onError: (err: unknown) => {
                 ctx.log?.error?.(`[${account.accountId}] NIP-17 reply error: ${String(err)}`);
               },
+            },
+            replyOptions: {
+              onModelSelected,
+              onToolStart: () => fireReaction(EVENT_EMOJI.toolStart),
+              onPlanUpdate: () => fireReaction(EVENT_EMOJI.planUpdate),
+              onCompactionStart: () => fireReaction(EVENT_EMOJI.compactionStart),
             },
           });
         },

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,5 +1,5 @@
 import { type ChannelPlugin, DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/core";
-import { createReplyPrefixOptions, createTypingCallbacks } from "openclaw/plugin-sdk/channel-runtime";
+import { createReplyPrefixOptions } from "openclaw/plugin-sdk/channel-runtime";
 import { buildChannelConfigSchema, collectStatusIssuesFromLastError, createDefaultChannelRuntimeState, formatPairingApproveHint } from "openclaw/plugin-sdk/nostr";
 import { Nip17ConfigSchema } from "./config-schema.js";
 import { normalizePubkey, startNip17Bus, type Nip17BusHandle } from "./nip17-bus.js";
@@ -17,13 +17,14 @@ import * as os from "os";
 const activeBuses = new Map<string, Nip17BusHandle>();
 
 // Visible feedback while a reply is being computed. Sent as kind:7 reactions
-// (NIP-25, gift-wrapped per NIP-17) targeting the inbound rumor. Single pass —
-// no looping; once exhausted, the row stops growing.
-const THINKING_EMOJIS = ["💭", "🧠", "🤔", "💡", "⚙️", "🔍", "📚", "⏳"];
-const THINKING_INTERVAL_MS = 5000;
+// (NIP-25, gift-wrapped per NIP-17) targeting the inbound rumor. One random
+// pick fires on reply-start; no keepalive cycle.
+const THINKING_EMOJIS = ["💭", "🧠", "🤔", "💡", "⏳"];
+const pickThinking = (): string =>
+  THINKING_EMOJIS[Math.floor(Math.random() * THINKING_EMOJIS.length)];
 
-// Event-driven reactions on top of the time-based cycle. Fired once per
-// dispatcher event, no dedup, no per-reply caps — stacking is desired UX.
+// Event-driven reactions. Fired once per dispatcher event, no dedup, no
+// per-reply caps — stacking is desired UX.
 const EVENT_EMOJI = {
   toolStart: "🔧",
   planUpdate: "📋",
@@ -222,11 +223,15 @@ export const nip17Plugin: ChannelPlugin<ResolvedNip17Account> = {
           const mediaDesc = hasMedia ? ` with ${media.length} media attachment(s)` : "";
           ctx.log?.info(`[${account.accountId}] NIP-17 DM from ${senderPubkey}${mediaDesc}: ${text.slice(0, 50)}...`);
 
-          // Receipt: fire-and-forget so the sender sees a reaction even if the
-          // reply pipeline guards short-circuit (pairing/policy/no-binding).
-          // Intentionally outside the typing cycle — this is a "received"
-          // signal, not a "thinking" signal.
-          void reactFn("🤙").catch(() => { /* logged via onError in bus */ });
+          // One helper for every reaction call site (receipt + onReplyStart +
+          // event-driven). reactFn already reports failures via onError.
+          const fireReaction = (emoji: string): void => {
+            void reactFn(emoji).catch(() => {});
+          };
+
+          // Receipt: fires before any guard / model selection so the sender
+          // sees something even when the reply pipeline short-circuits.
+          fireReaction("🤙");
 
           const cfg = runtime.config.loadConfig();
 
@@ -331,30 +336,6 @@ export const nip17Plugin: ChannelPlugin<ResolvedNip17Account> = {
             accountId: account.accountId,
           });
 
-          // Thinking cycle: walk THINKING_EMOJIS once, no looping. The
-          // dispatcher invokes start() on reply-start, then re-invokes it
-          // every keepaliveIntervalMs until first deliver, NO_REPLY, or abort
-          // — at which point onCleanup fires. maxDurationMs is a safety TTL.
-          let cycleIndex = 0;
-          const typing = createTypingCallbacks({
-            start: async () => {
-              if (cycleIndex >= THINKING_EMOJIS.length) return;
-              const emoji = THINKING_EMOJIS[cycleIndex++];
-              await reactFn(emoji);
-            },
-            stop: async () => { /* no completion emoji — reply DM is the signal */ },
-            onStartError: () => { /* swallow; reactFn already reports via onError */ },
-            keepaliveIntervalMs: THINKING_INTERVAL_MS,
-            maxDurationMs: THINKING_EMOJIS.length * THINKING_INTERVAL_MS,
-          });
-
-          // Event-driven reactions: fire-and-forget so the reply path is
-          // never blocked by a slow relay. reactFn already reports failures
-          // via onError. Coexists with the time-based cycle (stacking is OK).
-          const reactOnEvent = (emoji: string): void => {
-            void reactFn(emoji).catch(() => {});
-          };
-
           // Dispatch reply through the full pipeline
           await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
             ctx: ctxPayload,
@@ -362,11 +343,10 @@ export const nip17Plugin: ChannelPlugin<ResolvedNip17Account> = {
             dispatcherOptions: {
               ...prefixOptions,
               onModelSelected,
-              onReplyStart: typing.onReplyStart,
-              onTypingCleanup: typing.onCleanup,
-              onToolStart: () => reactOnEvent(EVENT_EMOJI.toolStart),
-              onPlanUpdate: () => reactOnEvent(EVENT_EMOJI.planUpdate),
-              onCompactionStart: () => reactOnEvent(EVENT_EMOJI.compactionStart),
+              onReplyStart: () => fireReaction(pickThinking()),
+              onToolStart: () => fireReaction(EVENT_EMOJI.toolStart),
+              onPlanUpdate: () => fireReaction(EVENT_EMOJI.planUpdate),
+              onCompactionStart: () => fireReaction(EVENT_EMOJI.compactionStart),
               deliver: async (payload: { text?: string; mediaPath?: string }) => {
                 const responseText = payload.text ?? "";
                 if (responseText.trim()) {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -22,6 +22,14 @@ const activeBuses = new Map<string, Nip17BusHandle>();
 const THINKING_EMOJIS = ["💭", "🧠", "🤔", "💡", "⚙️", "🔍", "📚", "⏳"];
 const THINKING_INTERVAL_MS = 5000;
 
+// Event-driven reactions on top of the time-based cycle. Fired once per
+// dispatcher event, no dedup, no per-reply caps — stacking is desired UX.
+const EVENT_EMOJI = {
+  toolStart: "🔧",
+  planUpdate: "📋",
+  compactionStart: "🗜️",
+} as const;
+
 async function ensureActiveBus(accountId: string): Promise<Nip17BusHandle> {
   const existing = activeBuses.get(accountId);
   if (existing) return existing;
@@ -340,6 +348,13 @@ export const nip17Plugin: ChannelPlugin<ResolvedNip17Account> = {
             maxDurationMs: THINKING_EMOJIS.length * THINKING_INTERVAL_MS,
           });
 
+          // Event-driven reactions: fire-and-forget so the reply path is
+          // never blocked by a slow relay. reactFn already reports failures
+          // via onError. Coexists with the time-based cycle (stacking is OK).
+          const reactOnEvent = (emoji: string): void => {
+            void reactFn(emoji).catch(() => {});
+          };
+
           // Dispatch reply through the full pipeline
           await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
             ctx: ctxPayload,
@@ -349,6 +364,9 @@ export const nip17Plugin: ChannelPlugin<ResolvedNip17Account> = {
               onModelSelected,
               onReplyStart: typing.onReplyStart,
               onTypingCleanup: typing.onCleanup,
+              onToolStart: () => reactOnEvent(EVENT_EMOJI.toolStart),
+              onPlanUpdate: () => reactOnEvent(EVENT_EMOJI.planUpdate),
+              onCompactionStart: () => reactOnEvent(EVENT_EMOJI.compactionStart),
               deliver: async (payload: { text?: string; mediaPath?: string }) => {
                 const responseText = payload.text ?? "";
                 if (responseText.trim()) {

--- a/src/nip17-bus.ts
+++ b/src/nip17-bus.ts
@@ -420,14 +420,14 @@ export async function startNip17Bus(options: Nip17BusOptions): Promise<Nip17BusH
 }
 
 // ============================================================================
-// Send NIP-17 DM
+// Publish NIP-17 wrapped rumors
 // ============================================================================
 
-async function sendNip17Dm(
+async function publishWrappedRumor(
   pool: SimplePool,
   sk: Uint8Array,
   toPubkey: string,
-  text: string,
+  rumorTemplate: { kind: number; content: string; tags: string[][]; created_at?: number },
   relays: string[],
   trustedRelays: Set<string>,
   onError?: (error: Error, context: string) => void,
@@ -458,17 +458,14 @@ async function sendNip17Dm(
     onError?.(new Error(`Adding recipient DM relays: ${extraRelays.join(", ")}`), "recipient-relays");
   }
 
-  // Create the kind 14 rumor (unsigned chat message)
-  const chatEvent = {
-    kind: 14,
-    content: text,
-    tags: [["p", toPubkey]], // Only receiver
-    created_at: Math.floor(Date.now() / 1000),
+  const event = {
+    ...rumorTemplate,
+    created_at: rumorTemplate.created_at ?? Math.floor(Date.now() / 1000),
   };
 
   // Manual NIP-59: rumor → seal → wrap
   // createWrap already signs with an ephemeral key — do NOT re-sign with sk
-  const rumor = require('nostr-tools/nip59').createRumor(chatEvent, sk);
+  const rumor = require('nostr-tools/nip59').createRumor(event, sk);
   const sealRecipient = require('nostr-tools/nip59').createSeal(rumor, sk, toPubkey);
   const wrapForRecipient = require('nostr-tools/nip59').createWrap(sealRecipient, toPubkey);
 
@@ -509,7 +506,7 @@ async function sendNip17Dm(
   }
 
   if (publishAttempts.length === 0) {
-    throw new Error("No publish attempts were started for the NIP-17 message");
+    throw new Error("No publish attempts were started for the wrapped rumor");
   }
 
   const settled = await Promise.allSettled(publishAttempts.map((attempt) => attempt.promise));
@@ -523,7 +520,7 @@ async function sendNip17Dm(
   const recipientFailures = recipientResults.filter((entry) => entry.result.status === "rejected");
 
   if (recipientResults.length === 0) {
-    throw new Error("No recipient publish attempts were created for the NIP-17 message");
+    throw new Error("No recipient publish attempts were created for the wrapped rumor");
   }
 
   if (recipientSuccesses.length === 0) {
@@ -542,4 +539,24 @@ async function sendNip17Dm(
       "publish"
     );
   }
+}
+
+async function sendNip17Dm(
+  pool: SimplePool,
+  sk: Uint8Array,
+  toPubkey: string,
+  text: string,
+  relays: string[],
+  trustedRelays: Set<string>,
+  onError?: (error: Error, context: string) => void,
+): Promise<void> {
+  await publishWrappedRumor(
+    pool,
+    sk,
+    toPubkey,
+    { kind: 14, content: text, tags: [["p", toPubkey]] },
+    relays,
+    trustedRelays,
+    onError,
+  );
 }

--- a/src/nip17-bus.ts
+++ b/src/nip17-bus.ts
@@ -53,7 +53,8 @@ export interface Nip17BusOptions {
     senderPubkey: string,
     text: string,
     reply: (text: string) => Promise<void>,
-    media?: DecryptedMedia[],
+    media: DecryptedMedia[] | undefined,
+    react: (emoji: string) => Promise<void>,
   ) => Promise<void>;
   onError?: (error: Error, context: string) => void;
   onConnect?: (relay: string) => void;
@@ -65,6 +66,7 @@ export interface Nip17BusHandle {
   close: () => void;
   publicKey: string;
   sendDm: (toPubkey: string, text: string) => Promise<void>;
+  sendReaction: (toPubkey: string, rumorId: string, emoji: string) => Promise<void>;
 }
 
 // ============================================================================
@@ -273,6 +275,16 @@ export async function startNip17Bus(options: Nip17BusOptions): Promise<Nip17BusH
         }
       };
 
+      // Create reaction function — targets this rumor (NIP-25 + ["k", "14"]),
+      // wrapped to prevent unhandled rejections
+      const reactFn = async (emoji: string): Promise<void> => {
+        try {
+          await sendNip17Reaction(pool, sk, senderPubkey, rumor.id, emoji, relays, trustedRelays, onError);
+        } catch (err) {
+          onError?.(err as Error, `react ${emoji} to ${senderPubkey}`);
+        }
+      };
+
       // Parse and decrypt media attachments (if any)
       let decryptedMedia: DecryptedMedia[] | undefined;
       
@@ -326,7 +338,7 @@ export async function startNip17Bus(options: Nip17BusOptions): Promise<Nip17BusH
         }
       }
 
-      await onMessage(senderPubkey, text, replyFn, decryptedMedia);
+      await onMessage(senderPubkey, text, replyFn, decryptedMedia, reactFn);
       lastRumorAt = Math.max(lastRumorAt, rumor.created_at);
       scheduleStatePersist(event.created_at, event.id);
     } catch (err) {
@@ -406,6 +418,10 @@ export async function startNip17Bus(options: Nip17BusOptions): Promise<Nip17BusH
     await sendNip17Dm(pool, sk, toPubkey, text, relays, trustedRelays, onError);
   };
 
+  const sendReaction = async (toPubkey: string, rumorId: string, emoji: string): Promise<void> => {
+    await sendNip17Reaction(pool, sk, toPubkey, rumorId, emoji, relays, trustedRelays, onError);
+  };
+
   return {
     close: () => {
       closed = true;
@@ -416,6 +432,7 @@ export async function startNip17Bus(options: Nip17BusOptions): Promise<Nip17BusH
     },
     publicKey: pk,
     sendDm,
+    sendReaction,
   };
 }
 
@@ -555,6 +572,33 @@ async function sendNip17Dm(
     sk,
     toPubkey,
     { kind: 14, content: text, tags: [["p", toPubkey]] },
+    relays,
+    trustedRelays,
+    onError,
+  );
+}
+
+// NIP-25 reaction wrapped per NIP-17. The ["k", "14"] tag tells clients the
+// reaction targets a kind:14 chat message; the ["e", rumorId] points at it.
+async function sendNip17Reaction(
+  pool: SimplePool,
+  sk: Uint8Array,
+  toPubkey: string,
+  rumorId: string,
+  emoji: string,
+  relays: string[],
+  trustedRelays: Set<string>,
+  onError?: (error: Error, context: string) => void,
+): Promise<void> {
+  await publishWrappedRumor(
+    pool,
+    sk,
+    toPubkey,
+    {
+      kind: 7,
+      content: emoji,
+      tags: [["e", rumorId], ["p", toPubkey], ["k", "14"]],
+    },
     relays,
     trustedRelays,
     onError,


### PR DESCRIPTION
Adds visible progress feedback to inbound NIP-17 DMs while the bot computes a reply. Each DM gets an immediate `received` reaction, a single random `thinking` reaction once the model is selected, and per-event reactions on tool calls, plan updates, and context compaction. The bus now publishes both DMs and reactions through one shared `publishWrappedRumor` helper, and `src/channel.ts` routes every reaction call site through a single `fireReaction` closure.

---

This is **incredibly useful to me** since it:

- shows that the clanker is online (reacts with "🤙" immediately)
- shows that the clanker is thinking (e.g. 🧠)
- shows that the clanker is still thinking... (e.g. ⏳ )
- also shows tool calls ( 🔧 ), plan updates ( 📋 ), and compactions ( 🗜️ )

### Screenshots (Wisp)

<img width="1008" height="589" alt="Screenshot_20260502-222807" src="https://github.com/user-attachments/assets/cca2c53e-1f36-41a2-81e6-ce5b076901ec" />

<img width="1008" height="593" alt="Screenshot_20260502-222829" src="https://github.com/user-attachments/assets/52085fa6-b432-4dc8-bd1a-b4660aeb54a0" />
